### PR TITLE
Implement pagination when getting series data

### DIFF
--- a/example.py
+++ b/example.py
@@ -6,7 +6,9 @@ from leveropen import Lever
 lever = Lever()
 dataset = lever.get_datasets_by_collection("Gross Domestic Product (GDP)")[0]
 fig, ax = plt.subplots()
-for series in tqdm(dataset.get_series(), desc="Parsing series objects", unit="SeriesObjects"):
+for series in tqdm(
+    dataset.get_series(), desc="Parsing series objects", unit="SeriesObjects"
+):
     data = series.get_data()["Value"]
     data.plot(
         title=f"Collection: {dataset.collection}\nTopic: {dataset.topic}",

--- a/leveropen/__init__.py
+++ b/leveropen/__init__.py
@@ -1,5 +1,5 @@
 """A package to access Lever Open API data"""
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 from leveropen.lever import Lever

--- a/leveropen/lever.py
+++ b/leveropen/lever.py
@@ -230,7 +230,6 @@ class Lever:
                 next_page = False
             else:
                 page += 1
-                print(f"Processing next page: {page}")
         if not datasets:
             spinner.fail("Loading datasets failed")
             raise ValueError(f"Dataset not found with query '{query}'")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 
 # Requirements
-with open('requirements.txt') as f:
+with open("requirements.txt") as f:
     required = f.read().splitlines()
     required.remove("pytest")
     required.remove("pytest-mock")
@@ -16,7 +16,7 @@ with open('requirements.txt') as f:
 # This call to setup() does all the work
 setup(
     name="leveropen",
-    version="0.0.1",
+    version="0.0.2",
     description="Python wrapper for Lever Open API",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -32,5 +32,5 @@ setup(
     include_package_data=True,
     install_requires=required,
     tests_require=["pytest", "pytest-mock"],
-    download_url="https://github.com/n-n-s/leveropen"
+    download_url="https://github.com/n-n-s/leveropen",
 )

--- a/tests/test_lever.py
+++ b/tests/test_lever.py
@@ -150,7 +150,7 @@ def test__parse_datasets(mock_lever, mock_datasets):
                 {"type": "Sector", "name": "Construction"},
                 {"type": "Sector", "name": "Services"},
             ],
-            series="example-base-url/v1/datasets/a/series?token=example-access-token"
+            series="example-base-url/v1/datasets/a/series?token=example-access-token",
         )
     ]
     actual = mock_lever._parse_datasets(datasets=datasets)


### PR DESCRIPTION
Fixes the issue that only the first page of series data of a dataset was being requested. This meant that if a dataset had more than 20 series then beyond the 20th series those series would not be retrieved.

The fix is achieved by looping through all pages of series data of a dataset. See method `leveropen.dataset._get_series_by_url()`